### PR TITLE
Upgrade hexo-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "dependencies": {
     "markdown-it": "^12.3.2",
-    "hexo-util": "^0.6.3"
+    "hexo-util": "^3.1.0"
   }
 }


### PR DESCRIPTION
This PR fixes https://github.com/kchen0x/hexo-reference/issues/15

This fix seems to work fine on my blog: <https://seekstar.github.io/2023/03/27/使用netns绕过wireguard/>

source code of this post: <https://gitee.com/searchstar/blog/raw/master/source/_posts/Linux/Network/使用netns绕过wireguard.md>